### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/niclashedam/hed.am/security/code-scanning/3](https://github.com/niclashedam/hed.am/security/code-scanning/3)

To fix the issue, add a `permissions` block to restrict GITHUB_TOKEN permissions to only what these jobs require. In this workflow, all jobs (`a11y`, `cspell`, `prettier`) perform read-only operations (checkout code, install dependencies, run checks) and do not need any write permissions to the repository or related items. Therefore, the minimal appropriate permissions are `contents: read`, which allows reading repository contents but prohibits any writes or updates. The permissions block should be added at the workflow (top/root) level, just beneath the workflow `name`, which will apply to all jobs within the workflow. No changes to steps or other regions needed, and no additional imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
