### PR TITLE
bug: typegraphy/prose not loaded automatically in tailwind v4

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1,5 +1,6 @@
 @import "./code.css";
 @import "tailwindcss";
+@plugin "@tailwindcss/typography";
 
 body {
   font-family: "Inter", sans-serif;


### PR DESCRIPTION
#6 Updated Tailwind to v4, but plugins are now manually added to `main.css`. This PR fixes that.